### PR TITLE
fix: parse return date string for roundtrip search

### DIFF
--- a/lib/src/features/search/presentation/screens/flight_search_results_screen.dart
+++ b/lib/src/features/search/presentation/screens/flight_search_results_screen.dart
@@ -220,6 +220,16 @@ class _FlightSearchResultsScreenState extends State<FlightSearchResultsScreen> {
     return '${hours}h ${remainingMinutes}m';
   }
 
+  DateTime? _parseReturnDate() {
+    final returnDateStr = widget.searchParams['return_date'] as String?;
+    if (returnDateStr != null && returnDateStr.isNotEmpty) {
+      try {
+        return DateFormat('dd/MM/yyyy').parse(returnDateStr);
+      } catch (_) {}
+    }
+    return null;
+  }
+
   Widget _buildViewDetailsButton() {
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 20),
@@ -234,7 +244,7 @@ class _FlightSearchResultsScreenState extends State<FlightSearchResultsScreen> {
                     flight: _selectedOutboundFlight!,
                     returnFlight: _selectedInboundFlight!,
                     passengers: _totalPassengers,
-                    returnDate: DateTime.tryParse(widget.searchParams['return_date'] ?? ''),
+                    returnDate: _parseReturnDate(),
                   ),
                 ),
               );


### PR DESCRIPTION
## Summary
- parse dd/MM/yyyy return date strings with DateFormat
- use parsed date when opening flight overview

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c15316ac608324b8bc0a4b71af7d71