### PR TITLE
Rename project to fly_journey

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,7 +13,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    namespace = "com.mycompany.CounterApp"
+    namespace = "com.flyjourney.app"
     compileSdk = flutter.compileSdkVersion
     // Pin NDK to a stable installed version to avoid SDK mismatches
     ndkVersion = "26.1.10909125"
@@ -38,7 +38,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.mycompany.CounterApp"
+        applicationId = "com.flyjourney.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/kotlin/com/example/yap/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/yap/MainActivity.kt
@@ -1,5 +1,0 @@
-package com.example.yap
-
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity : FlutterActivity()

--- a/android/app/src/main/kotlin/com/flyjourney/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/flyjourney/app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.mycompany.CounterApp
+package com.flyjourney.app
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mycompany.CounterApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flyjourney.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -494,7 +494,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mycompany.CounterApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flyjourney.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -512,7 +512,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mycompany.CounterApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flyjourney.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -528,7 +528,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mycompany.CounterApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flyjourney.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -659,7 +659,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mycompany.CounterApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flyjourney.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -681,7 +681,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mycompany.CounterApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flyjourney.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
-import 'package:cnh_n/src/features/splash/presentation/screens/splash_screen.dart';
-import 'package:cnh_n/src/features/home/presentation/screens/main_screen.dart';
-import 'package:cnh_n/src/features/auth/presentation/screens/login_screen.dart';
-import 'package:cnh_n/src/features/auth/presentation/screens/register_screen.dart';
-import 'package:cnh_n/src/features/auth/presentation/screens/otp_verification_screen.dart';
-import 'package:cnh_n/src/features/auth/data/services/auth_service.dart';
-import 'package:cnh_n/src/core/theme/app_theme.dart';
+import 'package:fly_journey/src/features/splash/presentation/screens/splash_screen.dart';
+import 'package:fly_journey/src/features/home/presentation/screens/main_screen.dart';
+import 'package:fly_journey/src/features/auth/presentation/screens/login_screen.dart';
+import 'package:fly_journey/src/features/auth/presentation/screens/register_screen.dart';
+import 'package:fly_journey/src/features/auth/presentation/screens/otp_verification_screen.dart';
+import 'package:fly_journey/src/features/auth/data/services/auth_service.dart';
+import 'package:fly_journey/src/core/theme/app_theme.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/src/core/theme/app_theme.dart
+++ b/lib/src/core/theme/app_theme.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 // Function to create a new TextTheme with scaled font sizes
 TextTheme _buildTextTheme(TextTheme base) {

--- a/lib/src/core/widgets/flight_card.dart
+++ b/lib/src/core/widgets/flight_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
 
 class FlightCard extends StatelessWidget {
   final Flight flight;

--- a/lib/src/core/widgets/flight_filters.dart
+++ b/lib/src/core/widgets/flight_filters.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 class FlightFilters extends StatefulWidget {
   final double? minPrice;

--- a/lib/src/core/widgets/hero_slider.dart
+++ b/lib/src/core/widgets/hero_slider.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 class HeroSlider extends StatefulWidget {
   const HeroSlider({super.key});

--- a/lib/src/core/widgets/search_app_bar.dart
+++ b/lib/src/core/widgets/search_app_bar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 class SearchAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;

--- a/lib/src/features/auth/data/services/auth_service.dart
+++ b/lib/src/features/auth/data/services/auth_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:cnh_n/src/core/config/api_config.dart';
+import 'package:fly_journey/src/core/config/api_config.dart';
 
 class User {
   final String id;

--- a/lib/src/features/auth/presentation/screens/forgot_password_screen.dart
+++ b/lib/src/features/auth/presentation/screens/forgot_password_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/features/auth/data/services/auth_service.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/auth/data/services/auth_service.dart';
 
 class ForgotPasswordScreen extends StatefulWidget {
   const ForgotPasswordScreen({super.key});

--- a/lib/src/features/auth/presentation/screens/login_screen.dart
+++ b/lib/src/features/auth/presentation/screens/login_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/features/auth/presentation/screens/register_screen.dart';
-import 'package:cnh_n/src/features/auth/presentation/screens/forgot_password_screen.dart';
-import 'package:cnh_n/src/features/auth/data/services/auth_service.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/auth/presentation/screens/register_screen.dart';
+import 'package:fly_journey/src/features/auth/presentation/screens/forgot_password_screen.dart';
+import 'package:fly_journey/src/features/auth/data/services/auth_service.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});

--- a/lib/src/features/auth/presentation/screens/otp_verification_screen.dart
+++ b/lib/src/features/auth/presentation/screens/otp_verification_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:cnh_n/src/features/auth/data/services/auth_service.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/auth/data/services/auth_service.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 class OtpVerificationScreen extends StatefulWidget {
   const OtpVerificationScreen({super.key});

--- a/lib/src/features/auth/presentation/screens/profile_screen.dart
+++ b/lib/src/features/auth/presentation/screens/profile_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/features/auth/data/services/auth_service.dart';
-import 'package:cnh_n/src/features/auth/presentation/screens/login_screen.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/auth/data/services/auth_service.dart';
+import 'package:fly_journey/src/features/auth/presentation/screens/login_screen.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});

--- a/lib/src/features/auth/presentation/screens/register_screen.dart
+++ b/lib/src/features/auth/presentation/screens/register_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/features/auth/data/services/auth_service.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/auth/data/services/auth_service.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});

--- a/lib/src/features/booking/data/services/storage_service.dart
+++ b/lib/src/features/booking/data/services/storage_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:cnh_n/src/features/booking/domain/models/booking.dart';
+import 'package:fly_journey/src/features/booking/domain/models/booking.dart';
 
 class StorageService {
   static const String _bookingsKey = 'bookings';

--- a/lib/src/features/booking/domain/models/booking.dart
+++ b/lib/src/features/booking/domain/models/booking.dart
@@ -1,5 +1,5 @@
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
-import 'package:cnh_n/src/features/booking/domain/models/passenger.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/features/booking/domain/models/passenger.dart';
 
 enum BookingStatus { confirmed, cancelled, completed }
 

--- a/lib/src/features/booking/presentation/screens/booking_confirmation_screen.dart
+++ b/lib/src/features/booking/presentation/screens/booking_confirmation_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/features/booking/presentation/screens/passenger_information_screen.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/booking/presentation/screens/passenger_information_screen.dart';
 
 class BookingConfirmationScreen extends StatelessWidget {
   final Flight outboundFlight;

--- a/lib/src/features/booking/presentation/screens/booking_screen.dart
+++ b/lib/src/features/booking/presentation/screens/booking_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
-import 'package:cnh_n/src/features/booking/domain/models/passenger.dart';
-import 'package:cnh_n/src/features/booking/domain/models/booking.dart';
-import 'package:cnh_n/src/features/booking/data/services/storage_service.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/features/booking/domain/models/passenger.dart';
+import 'package:fly_journey/src/features/booking/domain/models/booking.dart';
+import 'package:fly_journey/src/features/booking/data/services/storage_service.dart';
 
 class BookingScreen extends StatefulWidget {
   final Flight flight;

--- a/lib/src/features/booking/presentation/screens/flight_overview_screen.dart
+++ b/lib/src/features/booking/presentation/screens/flight_overview_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
-import 'package:cnh_n/src/features/booking/presentation/screens/booking_confirmation_screen.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/features/booking/presentation/screens/booking_confirmation_screen.dart';
 
 class FlightOverviewScreen extends StatelessWidget {
   final Flight flight;

--- a/lib/src/features/booking/presentation/screens/my_bookings_screen.dart
+++ b/lib/src/features/booking/presentation/screens/my_bookings_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/features/booking/domain/models/booking.dart';
-import 'package:cnh_n/src/features/booking/data/services/storage_service.dart';
+import 'package:fly_journey/src/features/booking/domain/models/booking.dart';
+import 'package:fly_journey/src/features/booking/data/services/storage_service.dart';
 
 class MyBookingsScreen extends StatefulWidget {
   final VoidCallback? onNavigateToSearch;

--- a/lib/src/features/booking/presentation/screens/passenger_information_screen.dart
+++ b/lib/src/features/booking/presentation/screens/passenger_information_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/features/booking/presentation/screens/payment_screen.dart';
-import 'package:cnh_n/src/features/booking/domain/models/passenger_models.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/booking/presentation/screens/payment_screen.dart';
+import 'package:fly_journey/src/features/booking/domain/models/passenger_models.dart';
 
 class PassengerInformationScreen extends StatefulWidget {
   final Flight outboundFlight;

--- a/lib/src/features/booking/presentation/screens/payment_screen.dart
+++ b/lib/src/features/booking/presentation/screens/payment_screen.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/features/booking/domain/models/passenger_models.dart';
-import 'package:cnh_n/src/features/booking/domain/models/booking.dart';
-import 'package:cnh_n/src/features/booking/domain/models/passenger.dart';
-import 'package:cnh_n/src/features/booking/data/services/storage_service.dart';
-import 'package:cnh_n/src/features/booking/presentation/screens/payment_success_screen.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/booking/domain/models/passenger_models.dart';
+import 'package:fly_journey/src/features/booking/domain/models/booking.dart';
+import 'package:fly_journey/src/features/booking/domain/models/passenger.dart';
+import 'package:fly_journey/src/features/booking/data/services/storage_service.dart';
+import 'package:fly_journey/src/features/booking/presentation/screens/payment_success_screen.dart';
 
 class PaymentScreen extends StatefulWidget {
   final Flight outboundFlight;

--- a/lib/src/features/booking/presentation/screens/payment_success_screen.dart
+++ b/lib/src/features/booking/presentation/screens/payment_success_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
-import 'package:cnh_n/src/features/booking/domain/models/passenger_models.dart';
-import 'package:cnh_n/src/features/home/presentation/screens/main_screen.dart';
-import 'package:cnh_n/src/features/search/presentation/screens/flight_search_step1_screen.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/features/booking/domain/models/passenger_models.dart';
+import 'package:fly_journey/src/features/home/presentation/screens/main_screen.dart';
+import 'package:fly_journey/src/features/search/presentation/screens/flight_search_step1_screen.dart';
 
 class PaymentSuccessScreen extends StatelessWidget {
   final Flight flight;

--- a/lib/src/features/connection/presentation/screens/connection_test_screen.dart
+++ b/lib/src/features/connection/presentation/screens/connection_test_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/features/search/data/flight_repository.dart';
-import 'package:cnh_n/src/core/config/api_config.dart';
+import 'package:fly_journey/src/features/search/data/flight_repository.dart';
+import 'package:fly_journey/src/core/config/api_config.dart';
 
 class ConnectionTestScreen extends StatefulWidget {
   const ConnectionTestScreen({super.key});

--- a/lib/src/features/home/presentation/screens/explore_screen.dart
+++ b/lib/src/features/home/presentation/screens/explore_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/widgets/expandable_destination_card.dart';
+import 'package:fly_journey/src/core/widgets/expandable_destination_card.dart';
 
 class ExploreScreen extends StatefulWidget {
   final String? selectedDestination;

--- a/lib/src/features/home/presentation/screens/explore_screen_new.dart
+++ b/lib/src/features/home/presentation/screens/explore_screen_new.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/widgets/expandable_destination_card.dart';
+import 'package:fly_journey/src/core/widgets/expandable_destination_card.dart';
 
 class ExploreScreen extends StatelessWidget {
   const ExploreScreen({super.key});

--- a/lib/src/features/home/presentation/screens/home_screen.dart
+++ b/lib/src/features/home/presentation/screens/home_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/features/search/presentation/screens/flight_search_step1_screen.dart';
-import 'package:cnh_n/src/features/notifications/presentation/screens/notifications_screen.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/core/widgets/hero_slider.dart';
-import 'package:cnh_n/src/core/config/api_config.dart';
+import 'package:fly_journey/src/features/search/presentation/screens/flight_search_step1_screen.dart';
+import 'package:fly_journey/src/features/notifications/presentation/screens/notifications_screen.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/core/widgets/hero_slider.dart';
+import 'package:fly_journey/src/core/config/api_config.dart';
 
 class HomePage extends StatefulWidget {
   final Function(String)? onNavigateToExplore;

--- a/lib/src/features/home/presentation/screens/main_screen.dart
+++ b/lib/src/features/home/presentation/screens/main_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/features/home/presentation/screens/home_screen.dart';
-import 'package:cnh_n/src/features/home/presentation/screens/explore_screen.dart';
-import 'package:cnh_n/src/features/booking/presentation/screens/my_bookings_screen.dart';
-import 'package:cnh_n/src/features/auth/presentation/screens/profile_screen.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/home/presentation/screens/home_screen.dart';
+import 'package:fly_journey/src/features/home/presentation/screens/explore_screen.dart';
+import 'package:fly_journey/src/features/booking/presentation/screens/my_bookings_screen.dart';
+import 'package:fly_journey/src/features/auth/presentation/screens/profile_screen.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 class MainScreen extends StatefulWidget {
   final int initialIndex;

--- a/lib/src/features/home/presentation/screens/news_screen.dart
+++ b/lib/src/features/home/presentation/screens/news_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/widgets/header.dart';
-import 'package:cnh_n/src/core/widgets/footer.dart';
+import 'package:fly_journey/src/core/widgets/header.dart';
+import 'package:fly_journey/src/core/widgets/footer.dart';
 
 class NewsScreen extends StatelessWidget {
   const NewsScreen({super.key});

--- a/lib/src/features/notifications/presentation/screens/notifications_screen.dart
+++ b/lib/src/features/notifications/presentation/screens/notifications_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 class NotificationsScreen extends StatefulWidget {
   const NotificationsScreen({super.key});

--- a/lib/src/features/search/data/flight_api_client.dart
+++ b/lib/src/features/search/data/flight_api_client.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'package:cnh_n/src/core/config/api_config.dart';
+import 'package:fly_journey/src/core/config/api_config.dart';
 
 class FlightApiException implements Exception {
   final String message;

--- a/lib/src/features/search/data/flight_repository.dart
+++ b/lib/src/features/search/data/flight_repository.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:cnh_n/src/core/config/api_config.dart';
+import 'package:fly_journey/src/core/config/api_config.dart';
 import 'flight_api_client.dart';
 
 class FlightRepository {

--- a/lib/src/features/search/domain/models/flight.dart
+++ b/lib/src/features/search/domain/models/flight.dart
@@ -1,6 +1,6 @@
-import 'package:cnh_n/src/features/search/domain/models/airport.dart';
-import 'package:cnh_n/src/features/search/domain/models/fare_class_details.dart';
-import 'package:cnh_n/src/features/search/domain/models/pricing.dart';
+import 'package:fly_journey/src/features/search/domain/models/airport.dart';
+import 'package:fly_journey/src/features/search/domain/models/fare_class_details.dart';
+import 'package:fly_journey/src/features/search/domain/models/pricing.dart';
 
 class Flight {
   final int? flightId;

--- a/lib/src/features/search/domain/models/roundtrip_search_response.dart
+++ b/lib/src/features/search/domain/models/roundtrip_search_response.dart
@@ -1,4 +1,4 @@
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
 
 class RoundtripSearchResponse {
   final String arrivalAirport;

--- a/lib/src/features/search/domain/models/search_data.dart
+++ b/lib/src/features/search/domain/models/search_data.dart
@@ -1,5 +1,5 @@
-import 'package:cnh_n/src/features/search/domain/models/airport.dart';
-import 'package:cnh_n/src/core/config/api_config.dart';
+import 'package:fly_journey/src/features/search/domain/models/airport.dart';
+import 'package:fly_journey/src/core/config/api_config.dart';
 
 class SearchData {
   // Step 1 - Basic Info

--- a/lib/src/features/search/presentation/screens/flight_details_screen.dart
+++ b/lib/src/features/search/presentation/screens/flight_details_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
-import 'package:cnh_n/src/features/booking/presentation/screens/booking_screen.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/features/booking/presentation/screens/booking_screen.dart';
 
 class FlightDetailsScreen extends StatelessWidget {
   final Flight flight;

--- a/lib/src/features/search/presentation/screens/flight_search_results_screen.dart
+++ b/lib/src/features/search/presentation/screens/flight_search_results_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/features/search/domain/models/airport.dart';
-import 'package:cnh_n/src/features/search/domain/models/flight.dart';
-import 'package:cnh_n/src/features/booking/presentation/screens/flight_overview_screen.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/features/search/data/flight_repository.dart';
+import 'package:fly_journey/src/features/search/domain/models/airport.dart';
+import 'package:fly_journey/src/features/search/domain/models/flight.dart';
+import 'package:fly_journey/src/features/booking/presentation/screens/flight_overview_screen.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/search/data/flight_repository.dart';
 
 class FlightSearchResultsScreen extends StatefulWidget {
   final Map<String, dynamic> searchParams;

--- a/lib/src/features/search/presentation/screens/flight_search_screen.dart
+++ b/lib/src/features/search/presentation/screens/flight_search_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/features/search/domain/models/airport.dart';
-import 'package:cnh_n/src/features/search/presentation/screens/flight_search_results_screen.dart';
-import 'package:cnh_n/src/features/notifications/presentation/screens/notifications_screen.dart';
-import 'package:cnh_n/src/features/connection/presentation/screens/connection_test_screen.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/core/widgets/flight_filters.dart';
+import 'package:fly_journey/src/features/search/domain/models/airport.dart';
+import 'package:fly_journey/src/features/search/presentation/screens/flight_search_results_screen.dart';
+import 'package:fly_journey/src/features/notifications/presentation/screens/notifications_screen.dart';
+import 'package:fly_journey/src/features/connection/presentation/screens/connection_test_screen.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/core/widgets/flight_filters.dart';
 
 class FlightSearchScreen extends StatefulWidget {
   const FlightSearchScreen({super.key});

--- a/lib/src/features/search/presentation/screens/flight_search_step1_screen.dart
+++ b/lib/src/features/search/presentation/screens/flight_search_step1_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/features/search/domain/models/search_data.dart';
-import 'package:cnh_n/src/features/search/presentation/screens/flight_search_step2_screen.dart';
-import 'package:cnh_n/src/core/widgets/search_app_bar.dart';
-import 'package:cnh_n/src/core/config/api_config.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/search/domain/models/search_data.dart';
+import 'package:fly_journey/src/features/search/presentation/screens/flight_search_step2_screen.dart';
+import 'package:fly_journey/src/core/widgets/search_app_bar.dart';
+import 'package:fly_journey/src/core/config/api_config.dart';
 
 class FlightSearchStep1Screen extends StatefulWidget {
   final SearchData? initialData;

--- a/lib/src/features/search/presentation/screens/flight_search_step2_screen.dart
+++ b/lib/src/features/search/presentation/screens/flight_search_step2_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/features/search/domain/models/search_data.dart';
-import 'package:cnh_n/src/features/search/domain/models/airport.dart';
-import 'package:cnh_n/src/features/search/presentation/screens/flight_search_step3_screen.dart';
-import 'package:cnh_n/src/core/widgets/flight_filters.dart';
-import 'package:cnh_n/src/core/widgets/search_app_bar.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/search/domain/models/search_data.dart';
+import 'package:fly_journey/src/features/search/domain/models/airport.dart';
+import 'package:fly_journey/src/features/search/presentation/screens/flight_search_step3_screen.dart';
+import 'package:fly_journey/src/core/widgets/flight_filters.dart';
+import 'package:fly_journey/src/core/widgets/search_app_bar.dart';
 
 class FlightSearchStep2Screen extends StatefulWidget {
   final SearchData searchData;

--- a/lib/src/features/search/presentation/screens/flight_search_step3_screen.dart
+++ b/lib/src/features/search/presentation/screens/flight_search_step3_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
-import 'package:cnh_n/src/features/search/domain/models/search_data.dart';
-import 'package:cnh_n/src/features/search/presentation/screens/flight_search_results_screen.dart';
-import 'package:cnh_n/src/core/widgets/search_app_bar.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
+import 'package:fly_journey/src/features/search/domain/models/search_data.dart';
+import 'package:fly_journey/src/features/search/presentation/screens/flight_search_results_screen.dart';
+import 'package:fly_journey/src/core/widgets/search_app_bar.dart';
 
 class FlightSearchStep3Screen extends StatefulWidget {
   final SearchData searchData;

--- a/lib/src/features/search/presentation/screens/search_screen.dart
+++ b/lib/src/features/search/presentation/screens/search_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/widgets/header.dart';
-import 'package:cnh_n/src/core/widgets/footer.dart';
+import 'package:fly_journey/src/core/widgets/header.dart';
+import 'package:fly_journey/src/core/widgets/footer.dart';
 
 class SearchScreen extends StatelessWidget {
   final String? from;

--- a/lib/src/features/splash/presentation/screens/splash_screen.dart
+++ b/lib/src/features/splash/presentation/screens/splash_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:cnh_n/src/core/constants/colors.dart';
+import 'package:fly_journey/src/core/constants/colors.dart';
 
 class SplashScreen extends StatefulWidget {
   final VoidCallback? onFinished;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: cnh_n
+name: fly_journey
 description: "Khám phá thế giới với ứng dụng đặt vé máy bay tiện lợi của chúng tôi, giúp bạn tìm kiếm, so sánh và đặt vé dễ dàng cho mọi hành trình."
 publish_to: "none"
 version: 1.0.0

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:cnh_n/src/features/splash/presentation/screens/splash_screen.dart';
+import 'package:fly_journey/src/features/splash/presentation/screens/splash_screen.dart';
 
 void main() {
   testWidgets('Splash screen shows app title', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- rename package to `fly_journey`
- update Android applicationId and iOS bundle identifiers
- adjust internal imports to new package name

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c168f64a0083249bf55af6cd4dd597